### PR TITLE
Expose `Binary` in task names to force finding a better solution

### DIFF
--- a/jvm/test-execution/README.md
+++ b/jvm/test-execution/README.md
@@ -25,15 +25,17 @@ _The stories (and other cards) below are listed according to the order in which 
    - Test should verify ability add multiple test suites of different types (`CUnit`, `JUnit`)
    - Test should verify rendering of `JUnitTestSuite` in components report (see `TestingNativeComponentReportIntegrationTest`)
  - Build user can execute tests using `gradle check`
-   - up to this point, users have been required to run tests with `<<suitename>>Test`, e.g. `mySuiteTest`. With the `testSuites` container in place, it should now be possible to tie test execution into the conventional `check` task lifecycle.
+   - up to this point, users have been required to run tests with `<<suitename>>BinaryTest`, e.g. `mySuiteBinaryTest`. With the `testSuites` container in place, it should now be possible to tie test execution into the conventional `check` task lifecycle.
    - Will need to extract a common concept of a 'run' task for all test suite binaries, so that [this rule](https://github.com/gradle/gradle/blob/229d8c7ef9995277e06362675606a0dfb90b9d5e/subprojects/platform-native/src/main/groovy/org/gradle/nativeplatform/test/plugins/NativeBinariesTestPlugin.java#L94-L94) can be pulled up into common infrastructure.
  - Build author can declare a test suite with a component under test
  - (`chore`) Add user guide documentation covering test execution stories implemented so far
    - Must include a sample.
 
-## Debt
-
 ## Not in Scope
+ - Fix "the Binary problem"
+   - All test execution-related tasks currently include `Binary` in the name. This reflects the reality that we "deal in binaries" in the Gradle software model, but in fact the concept of a "binary" makes little sense in the context of executing a test suite. We need to find a better way to capture this concept and then let it bubble up to the level of task naming, so that users have a better experience.
+ - Use `run<<Suitename>>` vs `<<suitename>>(Binary|Whatever)Test`
+   - This is a cross-cutting naming concern, but the assertion is that it is more natural for a user to type `gradle runMySuite`, or `gradle runIntegTests` than it is to type `gradle mySuiteTest` or `gradle integTestsTest`. Basically, tasks should lead with a verb.
  - Targeting multiple platforms
  - Reporting
    - should have some 'generic reporting' already by virtue of being a component

--- a/jvm/test-execution/with-dependencies/README.md
+++ b/jvm/test-execution/with-dependencies/README.md
@@ -9,11 +9,11 @@ The JUnit test class in this project depends on an external library (hamcrest). 
 
 ### Attempt to execute tests and succeed
 
-    $ ../../../gradlew clean mySuiteSuite
+    $ ../../../gradlew clean mySuiteBinary
     :jvm:test-execution:with-dependencies:clean
-    :jvm:test-execution:with-dependencies:compileMySuiteSuiteMySuiteJava
-    :jvm:test-execution:with-dependencies:mySuiteSuiteTest
-    :jvm:test-execution:with-dependencies:mySuiteSuite
+    :jvm:test-execution:with-dependencies:compileMySuiteBinaryMySuiteJava
+    :jvm:test-execution:with-dependencies:mySuiteBinaryTest
+    :jvm:test-execution:with-dependencies:mySuiteBinary
 
     BUILD SUCCESSFUL
 
@@ -26,7 +26,7 @@ Create a new build script that does not contain the hamcrest dependency.
 ### Attempt to execute tests and fail to compile
 Now run against the new build script and fail to compile as expected.
 
-    $ ../../../gradlew -b build.nodep.gradle clean mySuiteSuite
+    $ ../../../gradlew -b build.nodep.gradle clean mySuiteBinary
     :clean
     $FEATURES_HOME/jvm/test-execution/with-dependencies/src/test/java/MyTest.java:3: error: cannot find symbol
     import static org.hamcrest.Matchers.is;
@@ -42,12 +42,12 @@ Now run against the new build script and fail to compile as expected.
       symbol:   method is(int)
       location: class MyTest
     3 errors
-    :compileMySuiteSuiteMySuiteJava FAILED
+    :compileMySuiteBinaryMySuiteJava FAILED
 
     FAILURE: Build failed with an exception.
 
     * What went wrong:
-    Execution failed for task ':compileMySuiteSuiteMySuiteJava'.
+    Execution failed for task ':compileMySuiteBinaryMySuiteJava'.
     > Compilation failed; see the compiler error output for details.
 
     * Try:

--- a/jvm/test-execution/with-junit/README.md
+++ b/jvm/test-execution/with-junit/README.md
@@ -2,29 +2,29 @@
 
 ## Summary
 
-As a build user, I should be able to create a project that consists of a standalone JUnit test suite. I should be able to execute that test suite using `gradle mySuiteSuite`, and should be able to skip executing if all inputs are `UP-TO-DATE`.
+As a build user, I should be able to create a project that consists of a standalone JUnit test suite. I should be able to execute that test suite using `gradle mySuiteBinary`, and should be able to skip executing if all inputs are `UP-TO-DATE`.
 
 To be clear, there is no component under test in this story. Just a test suite.
 
 ## Usage
 
-### Clean, build, run mySuiteSuite and succeed
+### Clean, build, run mySuiteBinary and succeed
 
-    $ ../../../gradlew clean mySuiteSuite
+    $ ../../../gradlew clean mySuiteBinary
     :jvm:test-execution:with-junit:clean
-    :jvm:test-execution:with-junit:compileMySuiteSuiteMySuiteJava
-    :jvm:test-execution:with-junit:mySuiteSuiteTest
-    :jvm:test-execution:with-junit:mySuiteSuite
+    :jvm:test-execution:with-junit:compileMySuiteBinaryMySuiteJava
+    :jvm:test-execution:with-junit:mySuiteBinaryTest
+    :jvm:test-execution:with-junit:mySuiteBinary
 
     BUILD SUCCESSFUL
 
 
-### Build incrementally, run mySuiteSuite and succeed
+### Build incrementally, run mySuiteBinary and succeed
 
-    $ ../../../gradlew mySuiteSuite
-    :jvm:test-execution:with-junit:compileMySuiteSuiteMySuiteJava UP-TO-DATE
-    :jvm:test-execution:with-junit:mySuiteSuiteTest UP-TO-DATE
-    :jvm:test-execution:with-junit:mySuiteSuite UP-TO-DATE
+    $ ../../../gradlew mySuiteBinary
+    :jvm:test-execution:with-junit:compileMySuiteBinaryMySuiteJava UP-TO-DATE
+    :jvm:test-execution:with-junit:mySuiteBinaryTest UP-TO-DATE
+    :jvm:test-execution:with-junit:mySuiteBinary UP-TO-DATE
 
     BUILD SUCCESSFUL
 
@@ -47,22 +47,22 @@ $ git diff .
  }
 ```
 
-### Build incrementally, run mySuiteSuite and fail
+### Build incrementally, run mySuiteBinary and fail
 
-    $ ../../../gradlew mySuiteSuite
-    :jvm:test-execution:with-junit:compileMySuiteSuiteMySuiteJava
-    :jvm:test-execution:with-junit:mySuiteSuiteTest
+    $ ../../../gradlew mySuiteBinary
+    :jvm:test-execution:with-junit:compileMySuiteBinaryMySuiteJava
+    :jvm:test-execution:with-junit:mySuiteBinaryTest
 
     MyTest > test FAILED
         java.lang.AssertionError at MyTest.java:9
 
     1 test completed, 1 failed
-    :jvm:test-execution:with-junit:mySuiteSuiteTest FAILED
+    :jvm:test-execution:with-junit:mySuiteBinaryTest FAILED
 
     FAILURE: Build failed with an exception.
 
     * What went wrong:
-    Execution failed for task ':jvm:test-execution:with-junit:mySuiteSuiteTest'.
+    Execution failed for task ':jvm:test-execution:with-junit:mySuiteBinaryTest'.
     > There were failing tests. See the report at: file://$FEATURES_HOME/jvm/test-execution/with-junit/build/reports/tests/index.html
 
     * Try:

--- a/jvm/test-execution/with-resources/README.md
+++ b/jvm/test-execution/with-resources/README.md
@@ -7,12 +7,12 @@ As a build author, I should be able to place resources (properties files, etc) i
 
 ### Attempt to execute tests and succeed
 
-    $ ../../../gradlew clean mySuiteSuite
+    $ ../../../gradlew clean mySuiteBinary
     :jvm:test-execution:with-resources:clean
-    :jvm:test-execution:with-resources:compileMySuiteSuiteMySuiteJava
-    :jvm:test-execution:with-resources:processMySuiteSuiteMySuiteResources
-    :jvm:test-execution:with-resources:mySuiteSuiteTest
-    :jvm:test-execution:with-resources:mySuiteSuite
+    :jvm:test-execution:with-resources:compileMySuiteBinaryMySuiteJava
+    :jvm:test-execution:with-resources:processMySuiteBinaryMySuiteResources
+    :jvm:test-execution:with-resources:mySuiteBinaryTest
+    :jvm:test-execution:with-resources:mySuiteBinary
 
     BUILD SUCCESSFUL
 
@@ -23,21 +23,21 @@ As a build author, I should be able to place resources (properties files, etc) i
 
 ### Attempt to execute tests and fail
 
-    $ ../../../gradlew clean mySuiteSuite
+    $ ../../../gradlew clean mySuiteBinary
     :jvm:test-execution:with-resources:clean
-    :jvm:test-execution:with-resources:compileMySuiteSuiteMySuiteJava
-    :jvm:test-execution:with-resources:mySuiteSuiteTest
+    :jvm:test-execution:with-resources:compileMySuiteBinaryMySuiteJava
+    :jvm:test-execution:with-resources:mySuiteBinaryTest
 
     MyTest > test FAILED
         java.lang.AssertionError at MyTest.java:14
 
     1 test completed, 1 failed
-    :jvm:test-execution:with-resources:mySuiteSuiteTest FAILED
+    :jvm:test-execution:with-resources:mySuiteBinaryTest FAILED
 
     FAILURE: Build failed with an exception.
 
     * What went wrong:
-    Execution failed for task ':jvm:test-execution:with-resources:mySuiteSuiteTest'.
+    Execution failed for task ':jvm:test-execution:with-resources:mySuiteBinaryTest'.
     > There were failing tests. See the report at: file://$FEATURES_HOME/jvm/test-execution/with-resources/build/reports/tests/index.html
 
     * Try:


### PR DESCRIPTION
This PR is the result of a chat with @melix. It proposes exposing our `Binary` concept at the level of task names to force us to find a better concept and better name that will be more naturally intention-revealing to users (and ourselves).

Going this route allows us to move on with JVM Test Execution stories without engaging in more task naming exercises. We can factor off a card for dealing with what I am calling "the binary problem", and when that is fixed, it will (at least potentially) automatically make test execution task names that much better. In any case, we can revisit these task names at that time.

Feature: gradle/langos#102